### PR TITLE
Feature&Update: enable the autoset of ecutrho by dual value

### DIFF
--- a/apns/test/abacustest.py
+++ b/apns/test/abacustest.py
@@ -20,7 +20,7 @@ Example:
 """
 
 #ABACUS_IMAGE = "registry.dp.tech/deepmodeling/abacus-intel:latest"
-ABACUS_IMAGE = "registry.dp.tech/dptech/abacus:3.6.4" # this is for submit large batch of jobs, but need to always update
+ABACUS_IMAGE = "registry.dp.tech/dptech/abacus:3.7.3" # this is for submit large batch of jobs, but need to always update
 QE_IMAGE = "registry.dp.tech/dptech/prod-471/abacus-vasp-qe:20230116"
 VASP_IMAGE = "registry.dp.tech/dptech/prod-471/abacus-vasp-qe:20230116"
 PYTHON_IMAGE = "python:3.8"
@@ -514,18 +514,6 @@ if __name__ == "__main__":
     #jobgroup = "long-sp_ecohtest_lcao-v2.1"
     #fgroup = os.path.join(src, jobgroup)
     #os.chdir(fgroup)
-    os.chdir("/root/documents/simulation/abacus/test2/")
+    os.chdir("/root/documents/simulation/abacus/ultrasoft-20240816")
     folders = os.listdir()
     manual_submit("_", "_", "28682", 32, 64, folders)
-    #print(f"ABACUSTEST: Jobgroup {jobgroup} submitted.")
-    time.sleep(10)
-    exit()
-    jobgroups = [j for j in os.listdir(src) if os.path.isdir(os.path.join(src, j))]
-    for jobgroup in jobgroups:
-        fgroup = os.path.join(src, jobgroup)
-        os.chdir(fgroup)
-        folders = os.listdir()
-        manual_submit("_", "_", "28682", 2, 16, folders)
-        print(f"ABACUSTEST: Jobgroup {jobgroup} submitted.")
-        time.sleep(10)
-        os.chdir(src)

--- a/apns/test/main.py
+++ b/apns/test/main.py
@@ -138,10 +138,14 @@ def write_abacus(paramset: dict, atomset: list, cell: Cell):
     keys = ["INPUT", "STRU", "KPT"]
     # here it is possible to support the converged ecutwfc value auto-set for INPUT.
     # first get the fpp from atomset, then get the max, set to ecutwfc in paramset
-    ecut_set = paramset.get("ecutwfc", None) # if ecut_set is None or "auto", then set it to the max of fpp
-    if ecut_set is None or ecut_set == "auto":
+    ecutwfc_set = paramset.get("ecutwfc", None) # if ecut_set is None or "auto", then set it to the max of fpp
+    ecutrho_set = paramset.get("ecutrho", None)
+    if ecutwfc_set is None or ecutwfc_set == "auto":
         ecutwfc = max([as_.ecutwfc for as_ in atomset if as_.ecutwfc is not None])
         paramset["ecutwfc"] = ecutwfc
+    if isinstance(ecutrho_set, (int, float)) and ecutrho_set < 0: # negative value indicates the dual
+        ecutrho = ecutwfc * abs(ecutrho_set)
+        paramset["ecutrho"] = ecutrho
     vals = [write_abacus_input(paramset), write_abacus_stru(atomset, cell), write_abacus_kpt(cell)]
     return dict(zip(keys, vals))
 

--- a/apns/test/main.py
+++ b/apns/test/main.py
@@ -138,8 +138,8 @@ def write_abacus(paramset: dict, atomset: list, cell: Cell):
     keys = ["INPUT", "STRU", "KPT"]
     # here it is possible to support the converged ecutwfc value auto-set for INPUT.
     # first get the fpp from atomset, then get the max, set to ecutwfc in paramset
-    ecutwfc_set = paramset.get("ecutwfc", None) # if ecut_set is None or "auto", then set it to the max of fpp
-    ecutrho_set = paramset.get("ecutrho", None)
+    ecutwfc_set = paramset.get("ecutwfc") # if ecut_set is None or "auto", then set it to the max of fpp
+    ecutrho_set = paramset.get("ecutrho")
     if ecutwfc_set is None or ecutwfc_set == "auto":
         ecutwfc = max([as_.ecutwfc for as_ in atomset if as_.ecutwfc is not None])
         paramset["ecutwfc"] = ecutwfc


### PR DESCRIPTION
### What's changed
- now the autoset can support `ecutrho` by setting `ecutwfc` to `auto` and use dual value for `ecutrho`, will autoset its value to `ecutwfc*abs(dual)`. If a negative number is given as `ecutrho`, then it will be assumed as the dual value.
- update the ABACUS available image to 3.7.3 version to use the mended ultrasoft pseudopotential implementation
- complete the postprocessing exception catching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced data processing logic for APNS job analysis, improving data handling and output clarity.
	- Introduced visualization capabilities with new plotting function imports (currently commented out).
  
- **Bug Fixes**
	- Improved validation logic for handling incomplete data in APNS job analysis.

- **Documentation**
	- Updated test directory paths and container image versions, ensuring better compatibility and environment alignment.

- **Refactor**
	- Streamlined variable handling within parameter settings to improve clarity and functionality in processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->